### PR TITLE
Handling chalexpired-callback

### DIFF
--- a/HCaptcha/Assets/hcaptcha.html
+++ b/HCaptcha/Assets/hcaptcha.html
@@ -62,6 +62,7 @@
             "callback": onPass,
             "close-callback": closeCallback,
             "expired-callback": expiredCallback,
+            "chalexpired-callback": expiredCallback,
             "error-callback": errorCallback
           });
 


### PR DESCRIPTION
This callback is used in [Android-sdk](https://github.com/hCaptcha/hcaptcha-android-sdk/blob/af109c5ad8b52b50922dc5d9116ed85b6599b52e/sdk/src/main/assets/hcaptcha-form.html#L72), but is missing in iOS-sdk. Added to make behaviour the same.