### PR TITLE
Fix wrong tag pattern

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches: [ master, main ]
-    tags: [ '[0-9]+.[0-9]+.[0-9]+(\-.+)?' ]
+    tags: [ '[1-9]+.[0-9]+.[0-9]+*' ]
   pull_request:
   workflow_dispatch:
   repository_dispatch:


### PR DESCRIPTION
@e271828- looks like we need one more manuall `pod push`

tag pattern isn't regex https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet