### PR TITLE
Pass api_token explicitly to set_github_release action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,6 +48,7 @@ jobs:
         name: Release
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,6 +182,7 @@ platform :ios do
 
     set_github_release(
       repository_name: "hCaptcha/HCaptcha-ios-sdk",
+      api_token: ENV["GITHUB_TOKEN"],
       tag_name: tag,
       name: tag,
       description: changelog,


### PR DESCRIPTION
Fix for the failure on `set_github_release` https://github.com/hCaptcha/HCaptcha-ios-sdk/runs/5101583117?check_suite_focus=true