### PR TITLE
Test samples compilation on both 12 and 13 Xcode

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,13 +9,11 @@ on:
   repository_dispatch:
 
 jobs:
-  test_macOS:
-    name: Test HCaptcha
+  sdk:
+    name: Test SDK
     runs-on: macOS-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       - name: Use Xcode 12.4
         run: sudo xcode-select -switch /Applications/Xcode_12.4.app
@@ -28,24 +26,58 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-carthage-v2
 
-      - name: Prepare tools
-        run: |
-          brew upgrade carthage
+      - run: brew upgrade carthage
 
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.2
           bundler-cache: true
 
-      - name: Run tests
-        run: bundle exec fastlane ci
+      - run: bundle exec fastlane ci
 
-      - name: Compile samples
-        run: bundle exec fastlane ios samples_build
+  samples:
+    name: Build Samples
+    needs: sdk
+    runs-on: macos-11
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode: [ '12.4' ]
+        experimental: [ false ]
+        include:
+          - xcode: '13.2.1'
+            experimental: true
+    steps:
+      - uses: actions/checkout@v2
 
-      - if: startsWith(github.ref, 'refs/tags')
-        name: Release
+      - name: Use Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+
+      - run: bundle exec pod install
+        working-directory: Example
+
+      - run: bundle exec fastlane ios samples_build
+
+  release:
+    name: Relase
+    if: startsWith(github.ref, 'refs/tags')
+    needs: samples
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+
+      - name: Release
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [ master, main ]
     tags: [ '[1-9]+.[0-9]+.[0-9]+*' ]
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
   repository_dispatch:
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,7 +182,7 @@ platform :ios do
 
     set_github_release(
       repository_name: "hCaptcha/HCaptcha-ios-sdk",
-      api_token: ENV["GITHUB_TOKEN"],
+      api_bearer: ENV["GITHUB_TOKEN"],
       tag_name: tag,
       name: tag,
       description: changelog,


### PR DESCRIPTION
Changelist:
 - refactor workflow to 3 jobs and to test samples with different Xcode versions
 - don't run CI for documentation only changes
 - fix `set_github_release` issues, Per https://docs.fastlane.tools/actions/set_github_release/ we should use `api_bearer` instead `api_token`