### PR TITLE
Do not open WebView for passiveKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- Change: Now `configureWebView` is calling after WebView loading finished, before this it was called once `hCaptcha` showed
+
 # 2.0.0
 
 - **Breaking Change**:  error codes have been renamed and expanded to conform with the Android SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.1.0
 
-- Change: Now `configureWebView` is calling after WebView loading finished, before this it was called once `hCaptcha` showed
+- Change: you no longer need to set `webview.isHidden = true` on passive sitekeys. The webview is only unhidden if a visual challenge is shown, and `configureWebView` is now called after WebView finishes loading.
 
 # 2.0.0
 

--- a/Example/HCaptcha_Tests/RxSwift/HCaptcha+Rx__Tests.swift
+++ b/Example/HCaptcha_Tests/RxSwift/HCaptcha+Rx__Tests.swift
@@ -35,9 +35,10 @@ class HCaptcha_Rx__Tests: XCTestCase {
 
 
     func test__Validate__Token() {
+        let exp = expectation(description: "should call configureWebView")
         let hcaptcha = HCaptcha(manager: HCaptchaWebViewManager(messageBody: "{token: key}", apiKey: apiKey))
         hcaptcha.configureWebView { _ in
-            XCTFail("should not ask to configure the webview")
+            exp.fulfill()
         }
 
         do {
@@ -52,6 +53,7 @@ class HCaptcha_Rx__Tests: XCTestCase {
         catch let error {
             XCTFail(error.localizedDescription)
         }
+        waitForExpectations(timeout: 0)
     }
 
 
@@ -82,9 +84,10 @@ class HCaptcha_Rx__Tests: XCTestCase {
 
 
     func test__Validate__Error() {
+        let exp = expectation(description: "should call configureWebView")
         let hcaptcha = HCaptcha(manager: HCaptchaWebViewManager(messageBody: "\"foobar\"", apiKey: apiKey))
         hcaptcha.configureWebView { _ in
-            XCTFail("should not ask to configure the webview")
+            exp.fulfill()
         }
 
         do {
@@ -98,6 +101,7 @@ class HCaptcha_Rx__Tests: XCTestCase {
         catch let error {
             XCTAssertEqual(error as? HCaptchaError, .wrongMessageFormat)
         }
+        waitForExpectations(timeout: 0)
     }
 
     // MARK: - Did Finish Loading
@@ -182,16 +186,17 @@ class HCaptcha_Rx__Tests: XCTestCase {
     // MARK: - Dispose
 
     func test__Dispose() {
-        let exp = expectation(description: "stop loading")
+        let exp0 = expectation(description: "should call configureWebView")
+        let exp1 = expectation(description: "stop loading")
 
         // Stop
         let hcaptcha = HCaptcha(manager: HCaptchaWebViewManager(messageBody: "{log: \"foo\"}"))
         hcaptcha.configureWebView { _ in
-            XCTFail("should not ask to configure the webview")
+            exp0.fulfill()
         }
 
         let disposable = hcaptcha.rx.validate(on: presenterView)
-            .do(onDispose: exp.fulfill)
+            .do(onDispose: exp1.fulfill)
             .subscribe { _ in
                 XCTFail("should not validate")
             }
@@ -204,13 +209,19 @@ class HCaptcha_Rx__Tests: XCTestCase {
     // MARK: - Reset
 
     func test__Reset() {
+        var expCount = 0
+        let exp = expectation(description: "should call configureWebView")
+
         // Validate
         let hcaptcha = HCaptcha(
             manager: HCaptchaWebViewManager(messageBody: "{token: key}", apiKey: apiKey, shouldFail: true)
         )
 
         hcaptcha.configureWebView { _ in
-            XCTFail("should not ask to configure the webview")
+            expCount += 1
+            if expCount == 2 {
+                exp.fulfill()
+            }
         }
 
         do {
@@ -238,16 +249,24 @@ class HCaptcha_Rx__Tests: XCTestCase {
         catch let error {
             XCTFail(error.localizedDescription)
         }
+
+        waitForExpectations(timeout: 0)
     }
 
     func test__Validate__Reset_On_Error() {
+        var expCount = 0
+        let exp = expectation(description: "should call configureWebView")
+
         // Validate
         let hcaptcha = HCaptcha(
             manager: HCaptchaWebViewManager(messageBody: "{token: key}", apiKey: apiKey, shouldFail: true)
         )
 
         hcaptcha.configureWebView { _ in
-            XCTFail("should not ask to configure the webview")
+            expCount += 1
+            if expCount == 2 {
+                exp.fulfill()
+            }
         }
 
         do {
@@ -261,5 +280,7 @@ class HCaptcha_Rx__Tests: XCTestCase {
         catch let error {
             XCTFail(error.localizedDescription)
         }
+
+        waitForExpectations(timeout: 0)
     }
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AppSwizzle (1.3.1)
-  - HCaptcha/Core (2.0.0)
-  - HCaptcha/RxSwift (2.0.0):
+  - HCaptcha/Core (2.1.0)
+  - HCaptcha/RxSwift (2.1.0):
     - HCaptcha/Core
     - RxSwift (~> 6.2.0)
   - RxBlocking (6.2.0):
@@ -37,7 +37,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppSwizzle: db36e436f56110d93e5ae0147683435df593cabc
-  HCaptcha: a4c1efafe5a049c2db09d847736e369645d1079a
+  HCaptcha: 213cd06d9f6809e48e098a1647e65b749d30f28f
   RxBlocking: 0b29f7d2079109a8de49c411381bed7c33ef1eeb
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f

--- a/HCaptcha.podspec
+++ b/HCaptcha.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'HCaptcha'
-  s.version          = '2.0.0'
+  s.version          = '2.1.0'
   s.summary          = 'HCaptcha for iOS'
   s.swift_version    = '5.0'
   

--- a/HCaptcha/Assets/hcaptcha.html
+++ b/HCaptcha/Assets/hcaptcha.html
@@ -61,8 +61,10 @@
         try {
           if ("${size}" === 'invisible') {
             hcaptcha.execute(getExecuteOpts());
+          } else {
+            post({ action: "showHCaptcha" });
           }
-          post({ action: "showHCaptcha" });
+
           console.log("showing challenge");
         } catch (e) {
           console.log("failed to show challenge");
@@ -97,6 +99,11 @@
         post({ error: 30 });
       };
 
+      var openCallback = function(e) {
+        console.log("challenge opened", e);
+        post({ action: "showHCaptcha" });
+      };
+
       var onloadCallback = function() {
         try {
           console.log("challenge onload starting");
@@ -108,10 +115,10 @@
             "close-callback": closeCallback,
             "expired-callback": expiredCallback,
             "chalexpired-callback": expiredCallback,
-            "error-callback": errorCallback
+            "error-callback": errorCallback,
+            "open-callback": openCallback,
           });
 
-          // have loaded by this point; render is sync.
           post({ action: "didLoad" });
         } catch (e) {
           console.log("challenge failed to render");

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -140,7 +140,6 @@ internal class HCaptchaWebViewManager {
             return
         }
 #endif
-        webView.isHidden = false
         view.addSubview(webView)
 
         executeJS(command: .execute)
@@ -202,15 +201,18 @@ fileprivate extension HCaptchaWebViewManager {
             handle(error: error)
 
         case .showHCaptcha:
-            DispatchQueue.once(token: configureWebViewDispatchToken) { [weak self] in
-                guard let `self` = self else { return }
-                self.configureWebView?(self.webView)
-            }
+            webView.isHidden = false
 
         case .didLoad:
             didFinishLoading = true
             if completion != nil {
                 executeJS(command: .execute)
+            }
+            if configureWebView != nil {
+                DispatchQueue.once(token: configureWebViewDispatchToken) { [weak self] in
+                    guard let `self` = self else { return }
+                    self.configureWebView?(self.webView)
+                }
             }
 
         case .log(let message):


### PR DESCRIPTION
Better implementation of passiveKey handling

`configureWebView` calling logic changed, now it calls on `didLoad` event and not after first `validate` call. So this call may happens earlier, depends on initialization logic in the client's app

Action items:
 - [x] test 'regular' API keys
 - [x] test passive API keys
 - [x] update unit tests
 - [x] test timeout logic, just to know the behaviour
 - [x] test netwok issues handling

TODO:
 - [ ] update docmentation, in documentation callback is called `data-open-callback` but it doesn't looks working. Android uses `open-callback`, I have tried it on iOS and it works
