### PR TITLE
Reload HTML in WebView on validate call if networkError happened previously

### DIFF
--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -296,6 +296,9 @@ fileprivate extension HCaptchaWebViewManager {
                     self?.completion?(HCaptchaResult(error: error))
                     self?.lastError = nil
                 }
+                if error == .networkError {
+                    self.webView.loadHTMLString(formattedHTML, baseURL: baseURL)
+                }
             }
             return
         }


### PR DESCRIPTION
### Test cases

#### Network issues on `HCaptcha.init`

1. Turn off the internet on the test device (or dev machine, if testing on the simulator)
2. Launch test application
3. Press validate button
4. "Network issues" error shown
5. Turn on the internet
6. Press validate button one more time
**Problem:** Loader indicator doesn't disappear (SDK 'doesn't respond')
**Expected:** Loader indicator should disappear Captcha must be shown

#### Missing internet connection

1. Turn off the internet on the test device (or dev machine, if testing on the simulator)
2. Launch test application
3. Press validate button
4. "Network issues" error shown
6. Press validate button one more time
**Problem:** Loader indicator doesn't disappear (SDK 'doesn't respond')
**Expected:** Loader indicator should disappear, "Network issues" should be emitted again

The PR provide the fix for those issues