### PR TITLE
#72 add onEvent API

### DIFF
--- a/Example/HCaptcha/ViewController.swift
+++ b/Example/HCaptcha/ViewController.swift
@@ -75,6 +75,25 @@ class ViewController: UIViewController {
             .subscribe()
             .disposed(by: disposeBag)
 
+        hcaptcha.rx.events()
+            .debug("events")
+            .subscribe { [weak self] rxevent in
+                let event = rxevent.element?.0
+                _ = rxevent.element?.1
+
+                if event == .open {
+                    let alertController = UIAlertController(title: "On Event",
+                                                            message: "Opened",
+                                                            preferredStyle: .alert)
+                    self?.present(alertController, animated: true) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            alertController.dismiss(animated: true, completion: nil)
+                        }
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
+
         let validate = hcaptcha.rx.validate(on: view, resetOnError: false)
             .catch { error in
                 return .just("Error \(error)")

--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -491,4 +491,33 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
 
         waitForExpectations(timeout: 10)
     }
+
+    func test__On_Event_Callback() {
+        let exp0 = expectation(description: "should call configureWebView")
+        let exp1 = expectation(description: "setup key")
+        let exp2 = expectation(description: "hcaptcha opened")
+        var result: HCaptchaResult?
+
+        // Validate
+        let manager = HCaptchaWebViewManager(messageBody: "{token: key}", apiKey: apiKey)
+        manager.configureWebView { _ in
+            exp0.fulfill()
+        }
+        manager.onEvent = { (event, data) in
+            XCTAssertNil(data)
+            XCTAssertEqual(event, .open)
+            exp1.fulfill()
+        }
+
+        manager.validate(on: presenterView) { response in
+            result = response
+            exp2.fulfill()
+        }
+
+        waitForExpectations(timeout: 10)
+
+        XCTAssertNotNil(result)
+        XCTAssertNil(result?.error)
+        XCTAssertEqual(result?.token, apiKey)
+    }
 }

--- a/Example/HCaptcha_Tests/mock.html
+++ b/Example/HCaptcha_Tests/mock.html
@@ -35,6 +35,9 @@
                   post({"log": rqdata});
               }
               post(${message});
+              setTimeout(function() {
+                  post({ action: "onOpen" });
+              }, 100);
           }
       };
 

--- a/Example/ObjC/ViewController.m
+++ b/Example/ObjC/ViewController.m
@@ -31,6 +31,17 @@
         webView.frame = self.view.bounds;
         self.webView = webView;
     }];
+
+    [self.hCaptcha onEvent:^(enum HCaptchaEvent event, id _Nullable _) {
+        if (event == HCaptchaEventOpen) {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"On Event" message:@"Opened" preferredStyle:UIAlertControllerStyleAlert];
+            [self presentViewController:alert animated: YES completion:^{
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [alert dismissViewControllerAnimated:YES completion:nil];
+                });
+            }];
+        }
+    }];
 }
 
 - (IBAction) didPressButton:(UIButton *)button {

--- a/HCaptcha-Carthage.xcodeproj/project.pbxproj
+++ b/HCaptcha-Carthage.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1F833B7F271DC69C00E4DAB2 /* RxSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F833B7E271DC69C00E4DAB2 /* RxSwift.xcframework */; };
 		1F833B80271DC69C00E4DAB2 /* RxSwift.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F833B7E271DC69C00E4DAB2 /* RxSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E634944A2828856300130AC5 /* HCaptchaEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63494492828856300130AC5 /* HCaptchaEvent.swift */; };
 		E65145E327786BDB0079668A /* HCaptchaConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65145E227786BDB0079668A /* HCaptchaConfig.swift */; };
 		E6DB9EA827B15954008F0327 /* HCaptchaDebugInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DB9EA727B15954008F0327 /* HCaptchaDebugInfo.swift */; };
 		F206BAB51F8D3DE900A25807 /* HCaptcha-Carthage.h in Headers */ = {isa = PBXBuildFile; fileRef = F206BAB31F8D3DE900A25807 /* HCaptcha-Carthage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -50,6 +51,7 @@
 
 /* Begin PBXFileReference section */
 		1F833B7E271DC69C00E4DAB2 /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
+		E63494492828856300130AC5 /* HCaptchaEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaEvent.swift; sourceTree = "<group>"; };
 		E65145E227786BDB0079668A /* HCaptchaConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaConfig.swift; sourceTree = "<group>"; };
 		E6DB9EA727B15954008F0327 /* HCaptchaDebugInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaDebugInfo.swift; sourceTree = "<group>"; };
 		F206BAB01F8D3DE900A25807 /* HCaptcha.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HCaptcha.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -158,6 +160,7 @@
 		F24EA1D71F9683F5001DEC17 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				E63494492828856300130AC5 /* HCaptchaEvent.swift */,
 				E65145E227786BDB0079668A /* HCaptchaConfig.swift */,
 				F24EA1D81F9683F5001DEC17 /* HCaptchaDecoder.swift */,
 				E6DB9EA727B15954008F0327 /* HCaptchaDebugInfo.swift */,
@@ -309,6 +312,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E634944A2828856300130AC5 /* HCaptchaEvent.swift in Sources */,
 				F24EA1E51F968403001DEC17 /* HCaptchaError.swift in Sources */,
 				E65145E327786BDB0079668A /* HCaptchaConfig.swift in Sources */,
 				F24EA1E21F968403001DEC17 /* HCaptchaDecoder.swift in Sources */,

--- a/HCaptcha/Assets/hcaptcha.html
+++ b/HCaptcha/Assets/hcaptcha.html
@@ -102,6 +102,7 @@
       var openCallback = function(e) {
         console.log("challenge opened", e);
         post({ action: "showHCaptcha" });
+        post({ action: "onOpen" });
       };
 
       var onloadCallback = function() {

--- a/HCaptcha/Classes/HCaptcha.swift
+++ b/HCaptcha/Classes/HCaptcha.swift
@@ -103,6 +103,16 @@ public class HCaptcha: NSObject {
     }
 
     /**
+     - parameter reciever: A callback function
+
+       onEvent allow to subscribe to SDK's events
+     */
+    @objc
+    public func onEvent(_ reciever: ((HCaptchaEvent, Any?) -> Void)? = nil) {
+        manager.onEvent = reciever
+    }
+
+    /**
      - parameters:
          - view: The view that should present the webview.
          - resetOnError: If HCaptcha should be reset if it errors. Defaults to `true`.

--- a/HCaptcha/Classes/HCaptchaDecoder.swift
+++ b/HCaptcha/Classes/HCaptchaDecoder.swift
@@ -28,6 +28,9 @@ internal class HCaptchaDecoder: NSObject {
         /// Did finish loading resources
         case didLoad
 
+        /// Did a challenge become visible
+        case onOpen
+
         /// Logs a string onto the console
         case log(String)
     }
@@ -103,6 +106,9 @@ fileprivate extension HCaptchaDecoder.Result {
 
             case "didLoad":
                 return .didLoad
+
+            case "onOpen":
+                return .onOpen
 
             default:
                 break

--- a/HCaptcha/Classes/HCaptchaEvent.swift
+++ b/HCaptcha/Classes/HCaptchaEvent.swift
@@ -1,0 +1,33 @@
+//
+//  HCaptchaEvent.swift
+//  HCaptcha
+//
+//  Copyright © 2022 HCaptcha. All rights reserved.
+//
+
+import Foundation
+
+/** Events which can be received from HCaptcha SDK
+ */
+@objc
+public enum HCaptchaEvent: Int, RawRepresentable {
+    case open
+
+    public typealias RawValue = String
+
+    public var rawValue: RawValue {
+        switch self {
+        case .open:
+            return "open"
+        }
+    }
+
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case "open":
+            self = .open
+        default:
+            return nil
+        }
+    }
+}

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -44,6 +44,9 @@ internal class HCaptchaWebViewManager {
     /// Sends the result message
     var completion: ((HCaptchaResult) -> Void)?
 
+    /// Called when a challenge become visible
+    var onEvent: ((HCaptchaEvent, Any?) -> Void)?
+
     /// Notifies the JS bundle has finished loading
     var onDidFinishLoading: (() -> Void)? {
         didSet {
@@ -214,6 +217,9 @@ fileprivate extension HCaptchaWebViewManager {
                     self.configureWebView?(self.webView)
                 }
             }
+
+        case .onOpen:
+            onEvent?(.open, nil)
 
         case .log(let message):
             #if DEBUG

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -44,7 +44,7 @@ internal class HCaptchaWebViewManager {
     /// Sends the result message
     var completion: ((HCaptchaResult) -> Void)?
 
-    /// Called when a challenge become visible
+    /// Called (currently) when a challenge becomes visible
     var onEvent: ((HCaptchaEvent, Any?) -> Void)?
 
     /// Notifies the JS bundle has finished loading

--- a/HCaptcha/Classes/Rx/HCaptcha+Rx.swift
+++ b/HCaptcha/Classes/Rx/HCaptcha+Rx.swift
@@ -16,6 +16,22 @@ import HCaptcha
 public extension Reactive where Base: HCaptcha {
 
     /**
+     Returns observable which allows to listen for different events from SDK
+     */
+    func events() -> Observable<(HCaptchaEvent, Any?)> {
+        return Observable<(HCaptchaEvent, Any?)>.create { [weak base] observer -> Disposable in
+            base?.onEvent { (event, data) in
+                observer.onNext((event, data))
+            }
+
+            return Disposables.create {
+                observer.onCompleted()
+                base?.onEvent(nil)
+            }
+        }
+    }
+
+    /**
      - parameters:
         - view: The view that should present the webview.
         - resetOnError: If HCaptcha should be reset if it errors. Defaults to `true`

--- a/README.md
+++ b/README.md
@@ -216,11 +216,45 @@ This iOS SDK assumes by default that you want an "invisible" checkbox, i.e. that
 
 If you instead want the classic "normal" or "compact" checkbox behavior of showing a checkbox to tick and then either closing or showing a challenge, you can pass `size` to the HCaptcha initializer.
 
-```
+```swift
 let hcaptcha = try? HCaptcha(size: .compact)
 ```
 
 And you will now get the desired behavior.
+
+### SDK Events
+
+API allows you to listen for events from the SDK. At the moment the SDK supports:
+
+ - `open` event, which fired once hCaptcha is opened (visible to an app user)
+
+You can implement this with code below:
+
+``` swift
+let hcaptcha = try? HCaptcha(...)
+...
+hcaptcha.onEvent { (event, data) in
+    if event == .open {
+        ...
+    }
+}
+```
+
+For `RxSwift`:
+
+```swift
+let hcaptcha = try? HCaptcha(...)
+...
+hcaptcha.rx.events()
+    .subscribe { [weak self] rxevent in
+        let event = rxevent.element?.0
+
+        if event == .open {
+            ...
+        }
+    }
+    ...
+```
 
 ### SwiftUI Example
 

--- a/README.md
+++ b/README.md
@@ -224,11 +224,11 @@ And you will now get the desired behavior.
 
 ### SDK Events
 
-API allows you to listen for events from the SDK. At the moment the SDK supports:
+This SDK allows you to receive interaction events, for your analytics via the `onEvent` method. At the moment the SDK supports:
 
- - `open` event, which fired once hCaptcha is opened (visible to an app user)
+ - `open` event, which fires when hCaptcha is opened and a challenge is visible to an app user
 
-You can implement this with code below:
+You can implement this with the code below:
 
 ``` swift
 let hcaptcha = try? HCaptcha(...)


### PR DESCRIPTION
 - #72

Notes/Open questions

 - Callback in `onEvent` receives two params `event` and `data`. For now `data is always `nil` but it maybe useful in future to not introduce breaking changes
 - `onEvent` currently simply set a callback. To me it looks like we don't need more than one callback (hard to imagine use case when we will need it) Let me know if I'm wrong and we need to change it
 - I'm not 100% sure about dispose logic in RX API, I will continue testing