### PR TITLE
#78 add support for close, expired, challengeExpired, error events in onEvent API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.0
+
+- Feature: support more events in `onEvent` ([#78](https://github.com/hCaptcha/HCaptcha-ios-sdk/issues/78))
+
 # 2.2.0
 
 - Feature: the SDK allows you to receive interaction events for your analytics via the `onEvent` method ([#72](https://github.com/hCaptcha/HCaptcha-ios-sdk/issues/72))

--- a/Example/HCaptcha/ViewController.swift
+++ b/Example/HCaptcha/ViewController.swift
@@ -81,14 +81,12 @@ class ViewController: UIViewController {
                 let event = rxevent.element?.0
                 _ = rxevent.element?.1
 
-                if event == .open {
-                    let alertController = UIAlertController(title: "On Event",
-                                                            message: "Opened",
-                                                            preferredStyle: .alert)
-                    self?.present(alertController, animated: true) {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                            alertController.dismiss(animated: true, completion: nil)
-                        }
+                let alertController = UIAlertController(title: "On Event",
+                                                        message: event?.rawValue,
+                                                        preferredStyle: .alert)
+                self?.present(alertController, animated: true) {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        alertController.dismiss(animated: true, completion: nil)
                     }
                 }
             }

--- a/Example/HCaptcha/ViewController.swift
+++ b/Example/HCaptcha/ViewController.swift
@@ -77,12 +77,14 @@ class ViewController: UIViewController {
 
         hcaptcha.rx.events()
             .debug("events")
-            .subscribe { [weak self] rxevent in
-                let event = rxevent.element?.0
-                _ = rxevent.element?.1
+            .subscribe { [weak self] (event, data) in
+                if event == .error {
+                    let error = data as? HCaptchaError
+                    print("onEvent error: \(String(describing: error))")
+                }
 
                 let alertController = UIAlertController(title: "On Event",
-                                                        message: event?.rawValue,
+                                                        message: event.rawValue,
                                                         preferredStyle: .alert)
                 self?.present(alertController, animated: true) {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {

--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -381,7 +381,8 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
     func test__Validate__Reset_On_Error() {
         let exp0 = expectation(description: "should call configureWebView")
         var exp0Count = 0
-        let exp1 = expectation(description: "fail on first execution")
+        let exp1 = expectation(description: "should call onEvent")
+        let exp2 = expectation(description: "fail on first execution")
         var result: HCaptchaResult?
 
         // Validate
@@ -393,11 +394,17 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
             }
         }
 
+        manager.onEvent = { (event, error) in
+            XCTAssertEqual(.error, event)
+            XCTAssertEqual(HCaptchaError.wrongMessageFormat, error as? HCaptchaError)
+            exp1.fulfill()
+        }
+
         // Error
         manager.validate(on: presenterView, resetOnError: true) { response in
             result = response
 
-            exp1.fulfill()
+            exp2.fulfill()
         }
 
         waitForExpectations(timeout: 10)

--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -470,7 +470,7 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
         manager.onDidFinishLoading = exp.fulfill
         manager.reset()
 
-        waitForExpectations(timeout: 3)
+        waitForExpectations(timeout: 5)
     }
 
     func test__Invalid_Theme() {

--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -492,7 +492,7 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
-    func test__On_Event_Callback() {
+    func test__OnEvent_Open_Callback() {
         let exp0 = expectation(description: "should call configureWebView")
         let exp1 = expectation(description: "setup key")
         let exp2 = expectation(description: "hcaptcha opened")
@@ -519,5 +519,32 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertNil(result?.error)
         XCTAssertEqual(result?.token, apiKey)
+    }
+
+    func test__OnEvent_Without_Validation() {
+        let testParams: [(String, HCaptchaEvent)] = [("onChallengeExpired", .challengeExpired),
+                                                     ("onExpired", .expired),
+                                                     ("onClose", .close)]
+
+        testParams.forEach { (action, expectedEventType) in
+            let exp0 = expectation(description: "should call configureWebView")
+            let exp = expectation(description: "challenge expired received")
+
+            let manager = HCaptchaWebViewManager(messageBody: "{action: \"\(action)\"}")
+            manager.configureWebView { _ in
+                exp0.fulfill()
+            }
+            manager.onEvent = { (event, data) in
+                XCTAssertNil(data)
+                XCTAssertEqual(expectedEventType, event)
+                exp.fulfill()
+            }
+
+            manager.validate(on: presenterView) { _ in
+                XCTFail("should not validate")
+            }
+
+            waitForExpectations(timeout: 5)
+        }
     }
 }

--- a/Example/HCaptcha_Tests/Helpers/HCaptchaWebViewManager+Helpers.swift
+++ b/Example/HCaptcha_Tests/Helpers/HCaptchaWebViewManager+Helpers.swift
@@ -18,7 +18,7 @@ extension HCaptchaWebViewManager {
     }()
 
     convenience init(
-        messageBody: String = "",
+        messageBody: String = "undefined",
         apiKey: String? = nil,
         endpoint: URL? = nil,
         shouldFail: Bool = false,

--- a/Example/HCaptcha_Tests/mock.html
+++ b/Example/HCaptcha_Tests/mock.html
@@ -34,10 +34,13 @@
               if (rqdata) {
                   post({"log": rqdata});
               }
-              post(${message});
-              setTimeout(function() {
-                  post({ action: "onOpen" });
-              }, 100);
+              var messageToPost = ${message};
+              post(messageToPost);
+              if (messageToPost && messageToPost.token || messageToPost.action === "showHCaptcha") {
+                  setTimeout(function() {
+                      post({ action: "onOpen" });
+                  }, 100);
+              }
           }
       };
 

--- a/Example/ObjC/ViewController.m
+++ b/Example/ObjC/ViewController.m
@@ -33,14 +33,12 @@
     }];
 
     [self.hCaptcha onEvent:^(enum HCaptchaEvent event, id _Nullable _) {
-        if (event == HCaptchaEventOpen) {
-            UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"On Event" message:@"Opened" preferredStyle:UIAlertControllerStyleAlert];
-            [self presentViewController:alert animated: YES completion:^{
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    [alert dismissViewControllerAnimated:YES completion:nil];
-                });
-            }];
-        }
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"On Event" message: [NSString stringWithFormat:@"%ld", event, nil] preferredStyle:UIAlertControllerStyleAlert];
+        [self presentViewController:alert animated: YES completion:^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [alert dismissViewControllerAnimated:YES completion:nil];
+            });
+        }];
     }];
 }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - AppSwizzle (1.3.1)
-  - HCaptcha/Core (2.2.0)
-  - HCaptcha/RxSwift (2.2.0):
+  - HCaptcha/Core (2.3.0)
+  - HCaptcha/RxSwift (2.3.0):
     - HCaptcha/Core
     - RxSwift (~> 6.2.0)
   - RxBlocking (6.2.0):
@@ -37,7 +37,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppSwizzle: db36e436f56110d93e5ae0147683435df593cabc
-  HCaptcha: 638c5b3a064cd880090bc82eca3d8463d848e49f
+  HCaptcha: 80e8c94d913ecb7936e5591b3137c75a7b69a815
   RxBlocking: 0b29f7d2079109a8de49c411381bed7c33ef1eeb
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f

--- a/HCaptcha.podspec
+++ b/HCaptcha.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'HCaptcha'
-  s.version          = '2.2.0'
+  s.version          = '2.3.0'
   s.summary          = 'HCaptcha for iOS'
   s.swift_version    = '5.0'
   

--- a/HCaptcha/Assets/hcaptcha.html
+++ b/HCaptcha/Assets/hcaptcha.html
@@ -84,9 +84,12 @@
         post({ token: token });
       };
 
-      var expiredCallback = function() {
-        console.log("expired challenge");
-        post({ error: 15 });
+      var expiredCallback = function(action) {
+        return function() {
+          console.log("expired challenge");
+          post({ error: 15 });
+          post({ action: action });
+        };
       };
 
       var errorCallback = function(error) {
@@ -97,6 +100,7 @@
       var closeCallback = function() {
         console.log("challenge closed by user");
         post({ error: 30 });
+        post({ action: "onClose" });
       };
 
       var openCallback = function(e) {
@@ -114,8 +118,8 @@
             "theme": ${theme},
             "callback": onPass,
             "close-callback": closeCallback,
-            "expired-callback": expiredCallback,
-            "chalexpired-callback": expiredCallback,
+            "expired-callback": expiredCallback("onExpired"),
+            "chalexpired-callback": expiredCallback("onChallengeExpired"),
             "error-callback": errorCallback,
             "open-callback": openCallback,
           });

--- a/HCaptcha/Classes/HCaptchaDecoder.swift
+++ b/HCaptcha/Classes/HCaptchaDecoder.swift
@@ -31,6 +31,15 @@ internal class HCaptchaDecoder: NSObject {
         /// Did a challenge become visible
         case onOpen
 
+        /// Called when the user display of a challenge times out with no answer.
+        case onChallengeExpired
+
+        /// Called when the passcode response expires and the user must re-verify.
+        case onExpired
+
+        /// Called when the user dismisses a challenge.
+        case onClose
+
         /// Logs a string onto the console
         case log(String)
     }
@@ -100,18 +109,8 @@ fileprivate extension HCaptchaDecoder.Result {
         }
 
         if let action = response["action"] as? String {
-            switch action {
-            case "showHCaptcha":
-                return .showHCaptcha
-
-            case "didLoad":
-                return .didLoad
-
-            case "onOpen":
-                return .onOpen
-
-            default:
-                break
+            if let result = fromAction(action) {
+                return result
             }
         }
 
@@ -144,6 +143,31 @@ fileprivate extension HCaptchaDecoder.Result {
 
         default:
             return .error(.wrongMessageFormat)
+        }
+    }
+
+    private static func fromAction(_ action: String) -> HCaptchaDecoder.Result? {
+        switch action {
+        case "showHCaptcha":
+            return .showHCaptcha
+
+        case "didLoad":
+            return .didLoad
+
+        case "onOpen":
+            return .onOpen
+
+        case "onExpired":
+            return .onExpired
+
+        case "onChallengeExpired":
+            return .onChallengeExpired
+
+        case "onClose":
+            return .onClose
+
+        default:
+            return nil
         }
     }
 }

--- a/HCaptcha/Classes/HCaptchaEvent.swift
+++ b/HCaptcha/Classes/HCaptchaEvent.swift
@@ -12,6 +12,9 @@ import Foundation
 @objc
 public enum HCaptchaEvent: Int, RawRepresentable {
     case open
+    case expired
+    case challengeExpired
+    case close
 
     public typealias RawValue = String
 
@@ -19,6 +22,12 @@ public enum HCaptchaEvent: Int, RawRepresentable {
         switch self {
         case .open:
             return "open"
+        case .expired:
+            return "expired"
+        case .challengeExpired:
+            return "challengeExpired"
+        case .close:
+            return "close"
         }
     }
 
@@ -26,8 +35,27 @@ public enum HCaptchaEvent: Int, RawRepresentable {
         switch rawValue {
         case "open":
             self = .open
+        case "expired":
+            self = .expired
+        case "challengeExpired":
+            self = .challengeExpired
+        case "close":
+            self = .close
         default:
             return nil
         }
     }
+
+//    public init?(result: HCaptchaDecoder.Result) {
+//        switch result {
+//        case .onOpen
+//            self = .open
+//        case .onChallengeExpired
+//            self = .challengeExpired
+//        case .onExpired
+//            self = .expired
+//        case .onClose
+//            self = .close
+//        }
+//    }
 }

--- a/HCaptcha/Classes/HCaptchaEvent.swift
+++ b/HCaptcha/Classes/HCaptchaEvent.swift
@@ -15,6 +15,7 @@ public enum HCaptchaEvent: Int, RawRepresentable {
     case expired
     case challengeExpired
     case close
+    case error
 
     public typealias RawValue = String
 
@@ -28,6 +29,8 @@ public enum HCaptchaEvent: Int, RawRepresentable {
             return "challengeExpired"
         case .close:
             return "close"
+        case .error:
+            return "error"
         }
     }
 
@@ -41,21 +44,10 @@ public enum HCaptchaEvent: Int, RawRepresentable {
             self = .challengeExpired
         case "close":
             self = .close
+        case "error":
+            self = .error
         default:
             return nil
         }
     }
-
-//    public init?(result: HCaptchaDecoder.Result) {
-//        switch result {
-//        case .onOpen
-//            self = .open
-//        case .onChallengeExpired
-//            self = .challengeExpired
-//        case .onExpired
-//            self = .expired
-//        case .onClose
-//            self = .close
-//        }
-//    }
 }

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -202,6 +202,7 @@ fileprivate extension HCaptchaWebViewManager {
 
         case .error(let error):
             handle(error: error)
+            onEvent?(.error, error)
 
         case .showHCaptcha:
             webView.isHidden = false

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -207,19 +207,19 @@ fileprivate extension HCaptchaWebViewManager {
             webView.isHidden = false
 
         case .didLoad:
-            didFinishLoading = true
-            if completion != nil {
-                executeJS(command: .execute)
-            }
-            if configureWebView != nil {
-                DispatchQueue.once(token: configureWebViewDispatchToken) { [weak self] in
-                    guard let `self` = self else { return }
-                    self.configureWebView?(self.webView)
-                }
-            }
+            didLoad()
 
         case .onOpen:
             onEvent?(.open, nil)
+
+        case .onExpired:
+            onEvent?(.expired, nil)
+
+        case .onChallengeExpired:
+            onEvent?(.challengeExpired, nil)
+
+        case .onClose:
+            onEvent?(.close, nil)
 
         case .log(let message):
             #if DEBUG
@@ -244,6 +244,19 @@ fileprivate extension HCaptchaWebViewManager {
                 validate(on: view)
             } else {
                 completion?(HCaptchaResult(error: error))
+            }
+        }
+    }
+
+    private func didLoad() {
+        didFinishLoading = true
+        if completion != nil {
+            executeJS(command: .execute)
+        }
+        if configureWebView != nil {
+            DispatchQueue.once(token: configureWebViewDispatchToken) { [weak self] in
+                guard let `self` = self else { return }
+                self.configureWebView?(self.webView)
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ And you will now get the desired behavior.
 
 This SDK allows you to receive interaction events, for your analytics via the `onEvent` method. At the moment the SDK supports:
 
- - `open` event, which fires when hCaptcha is opened and a challenge is visible to an app user
+ - `open`  fires when hCaptcha is opened and a challenge is visible to an app user
+ - `expired` fires when the passcode response expires and the user must re-verify
+ - `challengeExpired` fires when the user display of a challenge times out with no answer
+ - `close` fires when the user dismisses a challenge.
 
 You can implement this with the code below:
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ This SDK allows you to receive interaction events, for your analytics via the `o
  - `expired` fires when the passcode response expires and the user must re-verify
  - `challengeExpired` fires when the user display of a challenge times out with no answer
  - `close` fires when the user dismisses a challenge.
- - `error` fires when any error happens during a challenge verification. Note: This event is not for error handling but only for analytics purposes. For error handling please check the `validate` API call
+ - `error` fires when any error happens during a challenge verification, for example a transient network error ( details about an error will be privided by `data` param, check example below). Note: This event is not for error handling but only for analytics purposes. For error handling please check the `validate` API call
 
 You can implement this with the code below:
 
@@ -239,6 +239,10 @@ let hcaptcha = try? HCaptcha(...)
 ...
 hcaptcha.onEvent { (event, data) in
     if event == .open {
+        ...
+    } else if event == .error {
+        let error = data as? HCaptchaError
+        print("onEvent error: \(String(describing: error))")
         ...
     }
 }
@@ -259,6 +263,8 @@ hcaptcha.rx.events()
     }
     ...
 ```
+
+
 
 ### SwiftUI Example
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ This SDK allows you to receive interaction events, for your analytics via the `o
  - `expired` fires when the passcode response expires and the user must re-verify
  - `challengeExpired` fires when the user display of a challenge times out with no answer
  - `close` fires when the user dismisses a challenge.
+ - `error` fires when any error happens during a challenge verification. Note: This event is not for error handling but only for analytics purposes. For error handling please check the `validate` API call
 
 You can implement this with the code below:
 


### PR DESCRIPTION
 - #78 

Implementation notes:
 - `close`, `expired`, `challengeExpired`, `error` event added
 - ~`data-callback` and `data-error-callback` wasn't added to `onEvent` API because they handled in different way (as far as I understand we don't need them in `onEvent`)~