### PR TITLE
Fix open _black links from WebView

### DIFF
--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -585,9 +585,9 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
         manager.configureWebView { _ in
             exp0.fulfill()
         }
-        wait(for: [exp0], timeout: 2)
+        wait(for: [exp0], timeout: 5)
         manager.validate(on: presenterView)
 
-        wait(for: [exp1, exp2], timeout: 1)
+        wait(for: [exp1, exp2], timeout: 5)
     }
 }

--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -554,4 +554,40 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
             waitForExpectations(timeout: 5)
         }
     }
+
+    func test__Open_External_Link() {
+        let exp0 = expectation(description: "should call configureWebView")
+        let exp1 = expectation(description: "_target link should be checked")
+        let exp2 = expectation(description: "_target link should be opened")
+
+        class TestURLOpener: HCaptchaURLOpener {
+            private let canOpenExpectation: XCTestExpectation
+            private let openExpectation: XCTestExpectation
+
+            init(_ canOpen: XCTestExpectation, _ open: XCTestExpectation) {
+                self.canOpenExpectation = canOpen
+                self.openExpectation = open
+            }
+
+            func canOpenURL(_ url: URL) -> Bool {
+                canOpenExpectation.fulfill()
+                return true
+            }
+
+            func openURL(_ url: URL) {
+                openExpectation.fulfill()
+            }
+        }
+
+        let manager = HCaptchaWebViewManager(messageBody: "{token: key, action: \"openExternalPage\"}",
+                                             apiKey: apiKey,
+                                             urlOpener: TestURLOpener(exp1, exp2))
+        manager.configureWebView { _ in
+            exp0.fulfill()
+        }
+        wait(for: [exp0], timeout: 2)
+        manager.validate(on: presenterView)
+
+        wait(for: [exp1, exp2], timeout: 1)
+    }
 }

--- a/Example/HCaptcha_Tests/Helpers/HCaptchaWebViewManager+Helpers.swift
+++ b/Example/HCaptcha_Tests/Helpers/HCaptchaWebViewManager+Helpers.swift
@@ -24,7 +24,8 @@ extension HCaptchaWebViewManager {
         shouldFail: Bool = false,
         size: HCaptchaSize = .invisible,
         rqdata: String? = nil,
-        theme: String = "\"light\""
+        theme: String = "\"light\"",
+        urlOpener: HCaptchaURLOpener = HCapchaAppURLOpener()
     ) {
         let html = String(format: HCaptchaWebViewManager.unformattedHTML,
                           arguments: [
@@ -38,7 +39,8 @@ extension HCaptchaWebViewManager {
             endpoint: endpoint,
             size: size,
             rqdata: rqdata,
-            theme: theme
+            theme: theme,
+            urlOpener: urlOpener
         )
     }
 
@@ -48,7 +50,8 @@ extension HCaptchaWebViewManager {
         endpoint: URL? = nil,
         size: HCaptchaSize = .invisible,
         rqdata: String? = nil,
-        theme: String = "\"light\""
+        theme: String = "\"light\"",
+        urlOpener: HCaptchaURLOpener = HCapchaAppURLOpener()
     ) {
         let localhost = URL(string: "http://localhost")!
 
@@ -59,7 +62,8 @@ extension HCaptchaWebViewManager {
             endpoint: endpoint ?? localhost,
             size: size,
             rqdata: rqdata,
-            theme: theme
+            theme: theme,
+            urlOpener: urlOpener
         )
     }
 

--- a/Example/HCaptcha_Tests/mock.html
+++ b/Example/HCaptcha_Tests/mock.html
@@ -60,6 +60,6 @@
   </head>
   <body>
     <span id="submit" style="visibility: hidden;"></span>
-    <a id="external-link" target="_blank" href="https://hcaptcha.com">Test external</a>
+    <a id="external-link" target="_blank" href="https://hcaptcha.com" rel="noopener">Test external</a>
   </body>
 </html>

--- a/Example/HCaptcha_Tests/mock.html
+++ b/Example/HCaptcha_Tests/mock.html
@@ -35,6 +35,9 @@
                   post({"log": rqdata});
               }
               var messageToPost = ${message};
+              if (messageToPost.action === "openExternalPage") {
+                  document.getElementById("external-link").click();
+              }
               post(messageToPost);
               if (messageToPost && messageToPost.token || messageToPost.action === "showHCaptcha") {
                   setTimeout(function() {
@@ -57,5 +60,6 @@
   </head>
   <body>
     <span id="submit" style="visibility: hidden;"></span>
+    <a id="external-link" target="_blank" href="https://hcaptcha.com">Test external</a>
   </body>
 </html>

--- a/HCaptcha-Carthage.xcodeproj/project.pbxproj
+++ b/HCaptcha-Carthage.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1F833B80271DC69C00E4DAB2 /* RxSwift.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F833B7E271DC69C00E4DAB2 /* RxSwift.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E634944A2828856300130AC5 /* HCaptchaEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63494492828856300130AC5 /* HCaptchaEvent.swift */; };
 		E65145E327786BDB0079668A /* HCaptchaConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65145E227786BDB0079668A /* HCaptchaConfig.swift */; };
+		E683772129053E560021BFD7 /* HCaptchaURLOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E683772029053E560021BFD7 /* HCaptchaURLOpener.swift */; };
 		E6BF595C288AE915007CE1CE /* HCaptchaHtml.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BF595B288AE915007CE1CE /* HCaptchaHtml.swift */; };
 		E6DB9EA827B15954008F0327 /* HCaptchaDebugInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DB9EA727B15954008F0327 /* HCaptchaDebugInfo.swift */; };
 		F206BAB51F8D3DE900A25807 /* HCaptcha-Carthage.h in Headers */ = {isa = PBXBuildFile; fileRef = F206BAB31F8D3DE900A25807 /* HCaptcha-Carthage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -54,7 +55,8 @@
 		1F833B7E271DC69C00E4DAB2 /* RxSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = RxSwift.xcframework; path = Carthage/Build/RxSwift.xcframework; sourceTree = "<group>"; };
 		E63494492828856300130AC5 /* HCaptchaEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaEvent.swift; sourceTree = "<group>"; };
 		E65145E227786BDB0079668A /* HCaptchaConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaConfig.swift; sourceTree = "<group>"; };
-		E6BF595B288AE915007CE1CE /* HCaptchaHtml.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HCaptchaHtml.swift; path = HCaptcha/Classes/HCaptchaHtml.swift; sourceTree = "<group>"; };
+		E683772029053E560021BFD7 /* HCaptchaURLOpener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaURLOpener.swift; sourceTree = "<group>"; };
+		E6BF595B288AE915007CE1CE /* HCaptchaHtml.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaHtml.swift; sourceTree = "<group>"; };
 		E6DB9EA727B15954008F0327 /* HCaptchaDebugInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HCaptchaDebugInfo.swift; sourceTree = "<group>"; };
 		F206BAB01F8D3DE900A25807 /* HCaptcha.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HCaptcha.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F206BAB31F8D3DE900A25807 /* HCaptcha-Carthage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "HCaptcha-Carthage.h"; sourceTree = "<group>"; };
@@ -97,7 +99,6 @@
 		F206BAA61F8D3DE900A25807 = {
 			isa = PBXGroup;
 			children = (
-				E6BF595B288AE915007CE1CE /* HCaptchaHtml.swift */,
 				F206BACF1F8D3E2800A25807 /* Cartfile */,
 				F206BAB21F8D3DE900A25807 /* HCaptcha-Carthage */,
 				F206BB1A1F8D4DBC00A25807 /* HCaptcha_RxSwift */,
@@ -174,6 +175,8 @@
 				F231B3991FEC51C800F82943 /* DispatchQueue+Throttle.swift */,
 				F24EA1DC1F9683F5001DEC17 /* Rx */,
 				F24EA1DE1F9683F5001DEC17 /* HCaptcha.swift */,
+				E683772029053E560021BFD7 /* HCaptchaURLOpener.swift */,
+				E6BF595B288AE915007CE1CE /* HCaptchaHtml.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -326,6 +329,7 @@
 				F24EA1E41F968403001DEC17 /* String+Dict.swift in Sources */,
 				F231B39A1FEC51C800F82943 /* DispatchQueue+Throttle.swift in Sources */,
 				E6DB9EA827B15954008F0327 /* HCaptchaDebugInfo.swift in Sources */,
+				E683772129053E560021BFD7 /* HCaptchaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HCaptcha/Classes/HCaptchaURLOpener.swift
+++ b/HCaptcha/Classes/HCaptchaURLOpener.swift
@@ -1,0 +1,43 @@
+//
+//  HCaptchaURLOpener.swift
+//  HCaptcha
+//
+//  Copyright © 2022 HCaptcha. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/**
+ * The protocol for a contractor which can handle/open URLs in an external viewer/browser
+ */
+internal protocol HCaptchaURLOpener {
+    /**
+     Return true if url can be handled
+     - parameter url: The URL to be checked
+     */
+    func canOpenURL(_ url: URL) -> Bool
+
+    /**
+     Handle passed url
+     - parameter url: The URL to be checked
+     */
+    func openURL(_ url: URL)
+}
+
+/**
+ * UIApplication based implementation
+ */
+internal class HCapchaAppURLOpener: HCaptchaURLOpener {
+    func canOpenURL(_ url: URL) -> Bool {
+        return UIApplication.shared.canOpenURL(url)
+    }
+
+    func openURL(_ url: URL) {
+        if #available(iOS 10.0, *) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        } else {
+            UIApplication.shared.openURL(url)
+        }
+    }
+}

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -339,10 +339,8 @@ fileprivate extension HCaptchaWebViewManager {
 extension HCaptchaWebViewManager: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        if navigationAction.targetFrame == nil, let url = navigationAction.request.url {
-            if urlOpener.canOpenURL(url) {
-                urlOpener.openURL(url)
-            }
+        if navigationAction.targetFrame == nil, let url = navigationAction.request.url, urlOpener.canOpenURL(url) {
+            urlOpener.openURL(url)
         }
         decisionHandler(WKNavigationActionPolicy.allow)
     }


### PR DESCRIPTION
 - https://github.com/hCaptcha/HCaptcha-ios-sdk/issues/99

Note:

 - By default WKWebView ignore `"target=_black"` links. So this PR just adds this (opens links in Safari)
 - I spent some time investigating why `webView.navigationDelegate = self` in `lazy init` lead to an infinite loop of crashes
    ```
    2022-10-21 10:42:18.035124+0200 HCaptcha_Example[84598:11349974] [Process] 0x11105c180 - [PID=0] WebProcessProxy::requestTermination: reason=2
    2022-10-21 10:42:18.035620+0200 HCaptcha_Example[84598:11349974] [Process] 0x11105c180 - [PID=0] WebProcessProxy::processDidTerminateOrFailedToLaunch: reason=2
    2022-10-21 10:42:18.036110+0200 HCaptcha_Example[84598:11349974] [Process] 0x7ff1f080d020 - [pageProxyID=6, webPageID=7, PID=0] WebPageProxy::processDidTerminate: (pid 0), reason 2
    2022-10-21 10:42:18.036817+0200 HCaptcha_Example[84598:11349974] [Loading] 0x7ff1f080d020 - [pageProxyID=6, webPageID=7, PID=0] WebPageProxy::dispatchProcessDidTerminate: reason=ExceededProcessCountLimit
    2022-10-21 10:42:18.049285+0200 HCaptcha_Example[84598:11349974] [Process] 0x11105c7c0
    ```
