### PR TITLE
feat(sdk): Allow user to explicitly call the webview render method.

### DIFF
--- a/HCaptcha/Classes/HCaptcha.swift
+++ b/HCaptcha/Classes/HCaptcha.swift
@@ -262,4 +262,9 @@ public class HCaptcha: NSObject {
     public convenience init(apiKey: String, baseURL: URL, locale: Locale, size: HCaptchaSize) throws {
         try self.init(apiKey: apiKey, baseURL: baseURL, locale: locale, size: size, rqdata: nil)
     }
+    
+    @objc
+    public func reload() {
+        self.manager.forceRedrawWebview()
+    }
 }

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -12,6 +12,7 @@ internal class HCaptchaWebViewManager: NSObject {
     enum JSCommand: String {
         case execute = "execute();"
         case reset = "reset();"
+        case reload = "reload();"
     }
 
     typealias Log = HCaptchaLogger
@@ -58,7 +59,7 @@ internal class HCaptchaWebViewManager: NSObject {
     var configureWebView: ((WKWebView) -> Void)?
 
     /// The dispatch token used to ensure `configureWebView` is only called once.
-    var configureWebViewDispatchToken = UUID()
+    public var configureWebViewDispatchToken = UUID()
 
     /// If the HCaptcha should be reset when it errors
     var shouldResetOnError = true
@@ -176,6 +177,10 @@ internal class HCaptchaWebViewManager: NSObject {
 
         executeJS(command: .execute)
     }
+    
+    func reload() {
+        executeJS(command: .reload)
+    }
 
     /// Stops the execution of the webview
     func stop() {
@@ -281,6 +286,10 @@ fileprivate extension HCaptchaWebViewManager {
                 self.configureWebView?(self.webView)
             }
         }
+    }
+    
+    public func forceRedrawWebview() {
+        self.configureWebView?(self.webView)
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -310,6 +310,24 @@ hcaptcha.validate(on: view, resetOnError: false) { result in
        ...
    }
 ```
+### Force the webview Redrawing
+
+If you want to update the CGRect of the webview displaying the Hcaptcha, (in cases where you may have other conflicting element on your app page), you can call hcaptcha.reload() to froce a redraw without resetting the challenge.
+
+```
+hcaptcha.validate(on: view) { result in
+
+	//You may want to compute a new height for your webview based on the state of the challenge
+    	let newHeight = 100
+
+	//reset your webview bounds
+	placeholder.uiview.bounds = CGRect(x:0,y:0,width:400,height:newHeight)	
+
+	//just call this method to explicitly redraw the webview
+	hcaptcha.reload()
+}
+```
+
 
 ### SwiftUI Example
 

--- a/README.md
+++ b/README.md
@@ -310,20 +310,20 @@ hcaptcha.validate(on: view, resetOnError: false) { result in
        ...
    }
 ```
-### Force the webview Redrawing
+### Forcing the Webview to Redraw
 
-If you want to update the CGRect of the webview displaying the Hcaptcha, (in cases where you may have other conflicting element on your app page), you can call hcaptcha.reload() to froce a redraw without resetting the challenge.
+If you want to update the `CGRect` of the webview displaying the HCaptcha control, e.g. in cases where you may have other conflicting element on your app page, you can call `hcaptcha.reload()` to force a redraw (re-render) without resetting the challenge.
 
 ```
 hcaptcha.validate(on: view) { result in
 
-	//You may want to compute a new height for your webview based on the state of the challenge
+	// You may want to compute a new height for your webview based on the state of the challenge
     	let newHeight = 100
 
-	//reset your webview bounds
+	// reset your webview bounds
 	placeholder.uiview.bounds = CGRect(x:0,y:0,width:400,height:newHeight)	
 
-	//just call this method to explicitly redraw the webview
+	// call this method to explicitly redraw the webview
 	hcaptcha.reload()
 }
 ```


### PR DESCRIPTION
added utility method bypass the webview renderToken via the Hcapcha class

closes #138 