### PR TITLE
ci: run release job only on release published

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
   release:
+    types: [published]
   workflow_dispatch:
   repository_dispatch:
 


### PR DESCRIPTION
During the last release (2.7.0) the workflow was triggered 3 times:

<img width="561" alt="Screenshot 2024-04-19 at 9 48 09 AM" src="https://github.com/hCaptcha/HCaptcha-ios-sdk/assets/2169738/8fe4d29c-0093-479d-87d5-ef7cb48f6255">

Because the workflow was activate to any type of release, now it will be activated for "type=published" only and it will happens one time