### PR TITLE
fix: keep ABI compatibility with 2.9.2 #180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.9.4
 
 - Feat: use `Locale.current` as default value for `locale` param in `HCaptcha` constructor
+- Fix: keep ABI compatibility with 2.9.2 #180
 
 # 2.9.3
 

--- a/HCaptcha/Classes/HCaptcha.swift
+++ b/HCaptcha/Classes/HCaptcha.swift
@@ -254,4 +254,42 @@ public class HCaptcha: NSObject {
     public convenience init(apiKey: String, baseURL: URL, locale: Locale, size: HCaptchaSize) throws {
         try self.init(apiKey: apiKey, baseURL: baseURL, locale: locale, size: size, rqdata: nil)
     }
+
+    @objc
+    public convenience init(apiKey: String?,
+                            passiveApiKey: Bool,
+                            baseURL: URL?,
+                            locale: Locale?,
+                            size: HCaptchaSize,
+                            orientation: HCaptchaOrientation,
+                            jsSrc: URL,
+                            rqdata: String?,
+                            sentry: Bool,
+                            endpoint: URL?,
+                            reportapi: URL?,
+                            assethost: URL?,
+                            imghost: URL?,
+                            host: String?,
+                            theme: String,
+                            customTheme: String?,
+                            diagnosticLog: Bool) throws {
+        try self.init(apiKey: apiKey,
+                      passiveApiKey: passiveApiKey,
+                      baseURL: baseURL,
+                      locale: locale,
+                      size: size,
+                      orientation: orientation,
+                      jsSrc: jsSrc,
+                      rqdata: rqdata,
+                      sentry: sentry,
+                      endpoint: endpoint,
+                      reportapi: reportapi,
+                      assethost: assethost,
+                      imghost: imghost,
+                      host: host,
+                      theme: theme,
+                      customTheme: customTheme,
+                      diagnosticLog: diagnosticLog,
+                      disablePat: false)
+    }
 }


### PR DESCRIPTION
 - #180 

This is hotfix, long term approach requires change in API to be similar to Android i.e. passing `HCaptchaConfig` to `HCaptcha.init`