### PR TITLE
Revert "fix: switch to fork of RxSwift to fix compilation with swift5 (#205)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IntuitionMachines/RxSwift", .branch("main"))
+        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.2.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
This reverts commit f86602d165ff88fd30638c8ca47b4d578bc5c7f3.

- https://github.com/ReactiveX/RxSwift/pull/2689#event-23204552768 - merged