### PR TITLE
Fix late webview completion race

### DIFF
--- a/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptchaWebViewManager__Tests.swift
@@ -77,6 +77,27 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
         XCTAssertEqual(result2?.token, apiKey)
     }
 
+    func test__Validate__Ignores_Late_Termination_After_Token() {
+        let exp = expectation(description: "load token")
+        var results = [HCaptchaResult]()
+
+        let manager = HCaptchaWebViewManager(messageBody: "{token: key}", apiKey: apiKey)
+        manager.validate(on: presenterView) { response in
+            results.append(response)
+            if results.count == 1 {
+                exp.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: TestTimeouts.standard)
+
+        manager.webViewWebContentProcessDidTerminate(manager.webView)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertNil(results.first?.error)
+        XCTAssertEqual(results.first?.token, apiKey)
+    }
+
 
     func test__Validate__Show_HCaptcha() {
         let exp = expectation(description: "show hcaptcha")

--- a/Example/HCaptcha_Tests/Core/HCaptcha__Bench.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptcha__Bench.swift
@@ -85,6 +85,13 @@ class HCaptcha__Bench: XCTestCase {
     func testBenchVerify() throws {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 400, height: 600))
         let hcaptcha = try? HCaptcha(apiKey: apiKey, size: .invisible)
+        let loaded = expectation(description: "loaded")
+
+        hcaptcha?.didFinishLoading {
+            loaded.fulfill()
+        }
+        wait(for: [loaded], timeout: TestTimeouts.long)
+
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: true, for: {
             let exp = expectation(description: "completed")
             hcaptcha?.validate(on: view, completion: { result in

--- a/Example/HCaptcha_Tests/Core/HCaptcha__Bench.swift
+++ b/Example/HCaptcha_Tests/Core/HCaptcha__Bench.swift
@@ -85,13 +85,6 @@ class HCaptcha__Bench: XCTestCase {
     func testBenchVerify() throws {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 400, height: 600))
         let hcaptcha = try? HCaptcha(apiKey: apiKey, size: .invisible)
-        let loaded = expectation(description: "loaded")
-
-        hcaptcha?.didFinishLoading {
-            loaded.fulfill()
-        }
-        wait(for: [loaded], timeout: TestTimeouts.long)
-
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: true, for: {
             let exp = expectation(description: "completed")
             hcaptcha?.validate(on: view, completion: { result in

--- a/HCaptcha/Classes/HCaptchaWebViewManager+Private.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager+Private.swift
@@ -207,12 +207,6 @@ extension HCaptchaWebViewManager {
     }
 
     func complete(_ result: HCaptchaResult) {
-        guard !resultHandled else {
-            Log.debug("WebViewManager.complete skip as handled")
-            return
-        }
-
-        resultHandled = true
         let completion = self.completion
         self.completion = nil
         completion?(result)

--- a/HCaptcha/Classes/HCaptchaWebViewManager+Private.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager+Private.swift
@@ -37,15 +37,18 @@ extension HCaptchaWebViewManager {
     func handle(result: HCaptchaDecoder.Result) {
         Log.debug("WebViewManager.handleResult: \(result)")
 
-        guard !resultHandled else {
-            Log.debug("WebViewManager.handleResult skip as handled")
-            return
-        }
-
         switch result {
         case .token(let token):
-            completion?(HCaptchaResult(self, token: token))
+            guard !resultHandled else {
+                Log.debug("WebViewManager.handleResult skip token as handled")
+                return
+            }
+            complete(HCaptchaResult(self, token: token))
         case .error(let error):
+            guard !resultHandled else {
+                Log.debug("WebViewManager.handleResult skip error as handled")
+                return
+            }
             handle(error: error)
             onEvent?(.error, error)
         case .showHCaptcha: webView.isHidden = false
@@ -66,11 +69,11 @@ extension HCaptchaWebViewManager {
                 reset()
                 validate(on: view)
             } else {
-                completion?(HCaptchaResult(self, error: error))
+                complete(HCaptchaResult(self, error: error))
             }
         } else {
-            if let completion = completion {
-                completion(HCaptchaResult(self, error: error))
+            if completion != nil {
+                complete(HCaptchaResult(self, error: error))
             } else {
                 lastError = error
             }
@@ -172,8 +175,8 @@ extension HCaptchaWebViewManager {
                     guard let self = self else { return }
                     Log.debug("WebViewManager complete with pendingError: \(error)")
 
-                    self.completion?(HCaptchaResult(self, error: error))
                     self.lastError = nil
+                    self.complete(HCaptchaResult(self, error: error))
                 }
                 if error == .networkError {
                     Log.debug("WebViewManager reloads html after \(error) error")
@@ -195,5 +198,17 @@ extension HCaptchaWebViewManager {
 
     func executeJS(command: JSCommand) {
         executeJS(command: command, didLoad: self.didFinishLoading)
+    }
+
+    func complete(_ result: HCaptchaResult) {
+        guard !resultHandled else {
+            Log.debug("WebViewManager.complete skip as handled")
+            return
+        }
+
+        resultHandled = true
+        let completion = self.completion
+        self.completion = nil
+        completion?(result)
     }
 }

--- a/HCaptcha/Classes/HCaptchaWebViewManager+Private.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager+Private.swift
@@ -38,19 +38,8 @@ extension HCaptchaWebViewManager {
         Log.debug("WebViewManager.handleResult: \(result)")
 
         switch result {
-        case .token(let token):
-            guard !resultHandled else {
-                Log.debug("WebViewManager.handleResult skip token as handled")
-                return
-            }
-            complete(HCaptchaResult(self, token: token))
-        case .error(let error):
-            guard !resultHandled else {
-                Log.debug("WebViewManager.handleResult skip error as handled")
-                return
-            }
-            handle(error: error)
-            onEvent?(.error, error)
+        case .token(let token): handleToken(token)
+        case .error(let error): handleDecoderError(error)
         case .showHCaptcha: webView.isHidden = false
         case .didLoad: didLoad()
         case .onOpen: onEvent?(.open, nil)
@@ -59,6 +48,23 @@ extension HCaptchaWebViewManager {
         case .onClose: onEvent?(.close, nil)
         case .log(_): break
         }
+    }
+
+    private func handleToken(_ token: String) {
+        guard !resultHandled else {
+            Log.debug("WebViewManager.handleResult skip token as handled")
+            return
+        }
+        complete(HCaptchaResult(self, token: token))
+    }
+
+    private func handleDecoderError(_ error: HCaptchaError) {
+        guard !resultHandled else {
+            Log.debug("WebViewManager.handleResult skip error as handled")
+            return
+        }
+        handle(error: error)
+        onEvent?(.error, error)
     }
 
     private func handle(error: HCaptchaError) {

--- a/HCaptcha/Classes/HCaptchaWebViewManager+WKNavigationDelegate.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager+WKNavigationDelegate.swift
@@ -30,13 +30,13 @@ extension HCaptchaWebViewManager: WKNavigationDelegate, WKUIDelegate {
     /// Tells the delegate that an error occurred during navigation.
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         Log.debug("WebViewManager.webViewDidFail with \(error)")
-        completion?(HCaptchaResult(self, error: .unexpected(error)))
+        complete(HCaptchaResult(self, error: .unexpected(error)))
     }
 
     /// Tells the delegate that an error occurred during the early navigation process.
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         Log.debug("WebViewManager.webViewDidFailProvisionalNavigation with \(error)")
-        completion?(HCaptchaResult(self, error: .unexpected(error)))
+        complete(HCaptchaResult(self, error: .unexpected(error)))
     }
 
     /// Tells the delegate that the web view’s content process was terminated.
@@ -49,7 +49,7 @@ extension HCaptchaWebViewManager: WKNavigationDelegate, WKUIDelegate {
                             userInfo: [
                                 NSLocalizedDescriptionKey: "WebView web content process did terminate",
                                 NSLocalizedRecoverySuggestionErrorKey: "Call HCaptcha.reset()"])
-        completion?(HCaptchaResult(self, error: .unexpected(error)))
         didFinishLoading = false
+        complete(HCaptchaResult(self, error: .unexpected(error)))
     }
 }

--- a/HCaptcha/Classes/HCaptchaWebViewManager.swift
+++ b/HCaptcha/Classes/HCaptchaWebViewManager.swift
@@ -154,7 +154,7 @@ internal class HCaptchaWebViewManager: NSObject {
 
         if !passiveApiKey {
             guard let view = view else {
-                completion?(HCaptchaResult(self, error: .failedSetup))
+                complete(HCaptchaResult(self, error: .failedSetup))
                 return
             }
 
@@ -171,6 +171,7 @@ internal class HCaptchaWebViewManager: NSObject {
     func stop() {
         Log.debug("WebViewManager.stop")
         stopInitWebViewConfiguration = true
+        completion = nil
         webView.stopLoading()
         resultHandled = true
         loadingTimer?.invalidate()


### PR DESCRIPTION
## Summary

This fixes the late-completion race behind the flaky `HCaptchaWebViewManager__Tests.test__Configure_Web_View` failure seen in GitHub Actions job 67922018521, while keeping `HCaptcha__Bench.testBenchVerify` measuring webview startup plus verification.

Reference:
- https://github.com/hCaptcha/HCaptcha-ios-sdk/actions/runs/23348009687/job/67922018521

## Root Cause

`HCaptchaWebViewManager` kept the active validation completion alive after delivering a terminal result.

That allowed later `WKNavigationDelegate` callbacks, especially `webViewWebContentProcessDidTerminate`, to re-enter the same completion path with an error result after success had already been delivered.

The earlier branch version tried to hide that race by preloading the benchmark before `measureMetrics`, but that changed what `testBenchVerify` measures. We do not want that benchmark warmed up ahead of time.

## What Changed

- Terminal result delivery now goes through `complete(...)`, which clears the stored completion before invoking it.
- `validate(on: nil)` now uses the same terminal completion path for `.failedSetup`.
- `stop()` clears any pending completion so post-stop callbacks cannot leak through.
- The benchmark warmup added in this branch was removed, so `testBenchVerify` still includes webview startup time.
- The regression test `test__Validate__Ignores_Late_Termination_After_Token` remains to cover the late-termination case directly.

## Validation

Ran locally:

- `xcodebuild test -workspace Example/HCaptcha.xcworkspace -scheme HCaptcha_Tests -destination 'platform=iOS Simulator,id=AD95999C-D8DE-4206-848B-AF7EC34B7EA9' -only-testing 'HCaptcha_Tests/HCaptchaWebViewManager__Tests/test__Validate__Ignores_Late_Termination_After_Token' -only-testing 'HCaptcha_Tests/HCaptchaWebViewManager__Tests/test__Configure_Web_View' -only-testing 'HCaptcha_Tests/HCaptchaWebViewManager__Tests/test__Stop'`
- `xcodebuild test -workspace Example/HCaptcha.xcworkspace -scheme HCaptcha_Tests -destination 'platform=iOS Simulator,id=AD95999C-D8DE-4206-848B-AF7EC34B7EA9' -only-testing 'HCaptcha_Tests/HCaptcha__Bench/testBenchVerify'`

Both passed.
